### PR TITLE
fixed issue where CS.update fails if countries.yml doesn't already exist

### DIFF
--- a/lib/city-state.rb
+++ b/lib/city-state.rb
@@ -37,7 +37,7 @@ module CS
       self.install(state_fn.split(".").last.upcase.to_sym) # reinstall country
     end
     @countries, @states, @cities = [{}, {}, {}] # invalidades cache
-    File.delete COUNTRIES_FN # force countries.yml to be generated at next call of CS.countries
+    File.delete COUNTRIES_FN if File.exist? COUNTRIES_FN # force countries.yml to be generated at next call of CS.countries
     true
   end
 


### PR DESCRIPTION
Installed on Rails 4.2 and CS.update was failing due to there being no conditional check on File.delete
