### PR TITLE
Fix wrong arguments number for cities lookup push

### DIFF
--- a/lib/city-state.rb
+++ b/lib/city-state.rb
@@ -180,7 +180,7 @@ module CS
           else
             index = @cities[country][state].index(old_value)
             if index.nil?
-              @cities[country][state][] = new_value
+              @cities[country][state].push(new_value)
             else
               @cities[country][state][index] = new_value
             end

--- a/lib/city-state/version.rb
+++ b/lib/city-state/version.rb
@@ -1,3 +1,3 @@
 module CS
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/city-state/version.rb
+++ b/lib/city-state/version.rb
@@ -1,3 +1,3 @@
 module CS
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Method `[] =` for `@cities` hash returned me an error, when I was trying to import missing cities using cities lookup strategy.
I changed `[] = ` method by `.push()` and then it worked!

![Captura de Tela 2021-03-04 às 13 59 01](https://user-images.githubusercontent.com/8607735/110006421-68633d80-7cf8-11eb-88fe-02c94a26d5e8.png)
