### PR TITLE
Remove instances of `File.exists` in favour of `File.exist?`

### DIFF
--- a/lib/city-state.rb
+++ b/lib/city-state.rb
@@ -75,7 +75,7 @@ module CS
 
   def self.install(country)
     # get CSV if doesn't exists
-    update_maxmind unless File.exists? MAXMIND_DB_FN
+    update_maxmind unless File.exist? MAXMIND_DB_FN
 
     # normalize "country"
     country = country.to_s.upcase
@@ -163,7 +163,7 @@ module CS
     # load the country file
     if self.blank?(@cities[country])
       cities_fn = File.join(FILES_FOLDER, "cities.#{country.to_s.downcase}")
-      self.install(country) if ! File.exists? cities_fn
+      self.install(country) if ! File.exist? cities_fn
       @cities[country] = self.symbolize_keys(YAML::load_file(cities_fn))
 
       # Remove duplicated cities
@@ -214,7 +214,7 @@ module CS
     if @cities_lookup.nil?
       @cities_lookup_fn  = DEFAULT_CITIES_LOOKUP_FN if @cities_lookup_fn.nil?
       @cities_lookup_fn  = File.expand_path(@cities_lookup_fn)
-      return nil if ! File.exists?(@cities_lookup_fn)
+      return nil if ! File.exist?(@cities_lookup_fn)
       @cities_lookup = self.symbolize_keys(YAML::load_file(@cities_lookup_fn)) # force countries to be symbols
       @cities_lookup.each { |key, value| @cities_lookup[key] = self.symbolize_keys(value) } # force states to be symbols
     end
@@ -228,7 +228,7 @@ module CS
     if @states_lookup.nil?
       @states_lookup_fn  = DEFAULT_STATES_LOOKUP_FN if @states_lookup_fn.nil?
       @states_lookup_fn  = File.expand_path(@states_lookup_fn)
-      return nil if ! File.exists?(@states_lookup_fn)
+      return nil if ! File.exist?(@states_lookup_fn)
       @states_lookup = self.symbolize_keys(YAML::load_file(@states_lookup_fn)) # force countries to be symbols
       @states_lookup.each { |key, value| @states_lookup[key] = self.symbolize_keys(value) } # force states to be symbols
     end
@@ -242,7 +242,7 @@ module CS
     if @countries_lookup.nil?
       @countries_lookup_fn  = DEFAULT_COUNTRIES_LOOKUP_FN if @countries_lookup_fn.nil?
       @countries_lookup_fn  = File.expand_path(@countries_lookup_fn)
-      return nil if ! File.exists?(@countries_lookup_fn)
+      return nil if ! File.exist?(@countries_lookup_fn)
       @countries_lookup = self.symbolize_keys(YAML::load_file(@countries_lookup_fn)) # force countries to be symbols
     end
 
@@ -260,7 +260,7 @@ module CS
     # Load the country file
     if self.blank?(@states[country])
       states_fn = File.join(FILES_FOLDER, "states.#{country.to_s.downcase}")
-      self.install(country) if ! File.exists? states_fn
+      self.install(country) if ! File.exist? states_fn
       @states[country] = self.symbolize_keys(YAML::load_file(states_fn))
 
       # Process lookup table
@@ -283,9 +283,9 @@ module CS
 
   # list of all countries of the world (countries.yml)
   def self.countries
-    if ! File.exists? COUNTRIES_FN
+    if ! File.exist? COUNTRIES_FN
       # countries.yml doesn't exists, extract from MAXMIND_DB
-      update_maxmind unless File.exists? MAXMIND_DB_FN
+      update_maxmind unless File.exist? MAXMIND_DB_FN
 
       # reads CSV line by line
       File.foreach(MAXMIND_DB_FN) do |line|


### PR DESCRIPTION
- `File.exists?` is [deprecated and removed.](https://bugs.ruby-lang.org/issues/17391)