### PR TITLE
Amend dependency

### DIFF
--- a/city-state.gemspec
+++ b/city-state.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_runtime_dependency "rubyzip", ">= 1.1"
+  spec.add_runtime_dependency "rubyzip", ">= 1.1", "< 3.0"
 end


### PR DESCRIPTION
While running `bundle install` I can see the following message

```
RubyZip 3.0 is coming!
**********************

The public API of some Rubyzip classes has been modernized to use named
parameters for optional arguments. Please check your usage of the
following classes:
  * `Zip::File`
  * `Zip::Entry`
  * `Zip::InputStream`
  * `Zip::OutputStream`

Please ensure that your Gemfiles and .gemspecs are suitably restrictive
to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
See https://github.com/rubyzip/rubyzip for details. The Changelog also
lists other enhancements and bugfixes that have been implemented since
version 2.3.0.
```

I think it is nice to prevent a problem, until it is tested with version 3.0