### PR TITLE
💚 ci: set up GitHub Actions for RSpec tests

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,32 @@
+name: RSpec Tests
+
+on:
+  push:
+    branches:
+      - main
+      - v0
+  pull_request:
+    branches:
+      - main
+      - v0
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: ['2.6', '3.0']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rspec


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for running RSpec tests. The workflow is triggered on pushes and pull requests to the `main` and `v0` branches and tests against Ruby versions 2.6 and 3.0 to ensure compatibility.