### PR TITLE
Use << to add missing city to the list

### DIFF
--- a/lib/city-state.rb
+++ b/lib/city-state.rb
@@ -181,7 +181,7 @@ module CS
           else
             index = @cities[country][state].index(old_value)
             if index.nil?
-              @cities[country][state][] = new_value
+              @cities[country][state] << new_value
             else
               @cities[country][state][index] = new_value
             end


### PR DESCRIPTION
Hey folks 👋 

I'm using ruby 3.2.2 and having a issue when adding a missing city. I added this yml to my project:
`db/cities-lookup.yml`

```yaml
BR:
  GO:
    "Mutunópolis": "Mutunópolis"
```
but when I run 
```ruby
CS.cities(:go, :br)
```
to test it fails for me because:

```
/Users/cadu/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/city-state-1.1.0/lib/city-state.rb:185:in `[]=': wrong number of arguments (given 1, expected 2..3) (ArgumentError)

              @cities[country][state][] = new_value
```

I think the idea of this line is to add a new_value to the existing array, so I changed it to include the new line